### PR TITLE
Update run_blip.py

### DIFF
--- a/run_blip.py
+++ b/run_blip.py
@@ -37,7 +37,8 @@ class LISA(LISAdata, Bayes):
         ## Figure out which response function to use for recoveries
         self.which_response()
         
-        #self.diag_spectra()
+        if self.params['lisa_config']=='stationary':
+            self.diag_spectra()
 
     def makedata(self):
         '''


### PR DESCRIPTION
diag_spectra doesn't work with orbiting LISA array sizes, so I relegated the call to stationary cases only.