### PR TITLE
Update run_blip.py

### DIFF
--- a/run_blip.py
+++ b/run_blip.py
@@ -249,33 +249,31 @@ class LISA(LISAdata, likelihoods):
 
             # Power spectra of the SGWB
             Sgw = (3.0*(H0**2)*Omegaf)/(4*np.pi*np.pi*self.fdata**3)
-
+            
             # Spectrum of the SGWB signal convoluted with the detector response tensor.
-            S1_gw, S2_gw, S3_gw = Sgw*R1, Sgw*R2, Sgw*R3
+            S1_gw, S2_gw, S3_gw = Sgw[:, None]*R1, Sgw[:, None]*R2, Sgw[:, None]*R3
 
             # The total noise spectra is the sum of the instrumental + astrophysical
-            S1, S2, S3 = S1 + S1_gw, S2 + S2_gw, S3 + S3_gw
+            S1, S2, S3 = S1[:, None] + S1_gw, S2[:, None] + S2_gw, S3[:, None] + S3_gw
 
-            plt.loglog(self.fdata, S1_gw, label='gw required')
+            plt.loglog(self.fdata, np.mean(S1_gw,axis=1), label='gw required')
 
 
-        plt.loglog(self.fdata, S3, label='required')
+        plt.loglog(self.fdata, np.mean(S3,axis=1), label='required')
         plt.loglog(psdfreqs, data_PSD3,label='PSD of the data series', alpha=0.6)
         plt.xlabel('f in Hz')
         plt.ylabel('Power Spectrum ')
         plt.legend()
-        plt.ylim([1e-44, 5e-40])
         plt.grid()
+        plt.ylim([1e-44, 5e-40])
         plt.xlim(0.5*self.params['fmin'], 2*self.params['fmax'])
-
-
         plt.savefig(self.params['out_dir'] + '/diag_psd.png', dpi=200)
         print('Diagnostic spectra plot made in ' + self.params['out_dir'] + '/diag_psd.png')
         plt.close()
 
 
         ## lets also plot psd residue.
-        rel_res_mean = (data_PSD3 - S3)/S3
+        rel_res_mean = (data_PSD3 - np.mean(S3,axis=1))/np.mean(S3,axis=1)
 
         plt.semilogx(self.fdata, rel_res_mean , label='relative mean residue')
         plt.xlabel('f in Hz')
@@ -284,7 +282,6 @@ class LISA(LISAdata, likelihoods):
         plt.legend()
         plt.grid()
         plt.xlim(0.5*self.params['fmin'], 2*self.params['fmax'])
-
 
         plt.savefig(self.params['out_dir'] + '/res_psd.png', dpi=200)
         print('Residue spectra plot made in ' + self.params['out_dir'] + '/res_psd.png')
@@ -300,12 +297,12 @@ class LISA(LISAdata, likelihoods):
         elif self.params['modeltype'] == 'sph_sgwb':
             Sx = C_noise[ii, jj, :] + Sgw*summ_response_mat[ii, jj, :, 0]
         else:
-            Sx = C_noise[ii, jj, :] + Sgw*self.response_mat[ii, jj, :, 0]
+            Sx = C_noise[ii, jj, :, None] + Sgw[:,None]*self.response_mat[ii, jj, :, 0]
 
         CSDx = np.mean(np.conj(self.rbar[:, :, ii]) * self.rbar[:, :, jj], axis=1)
 
         plt.subplot(2, 1, 1)
-        plt.loglog(self.fdata, np.abs(np.real(Sx)), label='Re(Required ' + str(ii+1) + str(jj+1) + ')' )
+        plt.loglog(self.fdata, np.mean(np.abs(np.real(Sx)),axis=1), label='Re(Required ' + str(ii+1) + str(jj+1) + ')' )
         plt.loglog(psdfreqs, np.abs(np.real(CSDx)) ,label='Re(CSD' + str(ii+1) + str(jj+1) + ')', alpha=0.6)
         plt.xlabel('f in Hz')
         plt.ylabel('Power in 1/Hz')
@@ -315,7 +312,7 @@ class LISA(LISAdata, likelihoods):
         plt.grid()
 
         plt.subplot(2, 1, 2)
-        plt.loglog(self.fdata, np.abs(np.imag(Sx)), label='Im(Required ' + str(ii+1) + str(jj+1) + ')' )
+        plt.loglog(self.fdata, np.mean(np.abs(np.imag(Sx)),axis=1), label='Im(Required ' + str(ii+1) + str(jj+1) + ')' )
         plt.loglog(psdfreqs, np.abs(np.imag(CSDx)) ,label='Im(CSD' + str(ii+1) + str(jj+1) + ')', alpha=0.6)
         plt.xlabel('f in Hz')
         plt.ylabel(' Power in 1/Hz')
@@ -323,11 +320,9 @@ class LISA(LISAdata, likelihoods):
         plt.xlim(0.5*self.params['fmin'], 2*self.params['fmax'])
         plt.ylim([1e-44, 5e-40])
         plt.grid()
-
         plt.savefig(self.params['out_dir'] + '/diag_csd_' + str(ii+1) + str(jj+1) + '.png', dpi=200)
         print('Diagnostic spectra plot made in ' + self.params['out_dir'] + '/diag_csd_' + str(ii+1) + str(jj+1) + '.png')
         plt.close()
-
 
 def blip(paramsfile='params.ini'):
     '''


### PR DESCRIPTION
Fixed: the legend/line overflow problem in the diagnostic plots. The issue was that all time segments were being plotted instead of taking a mean over time.
Extant issues: The grid and axes for diag_psd are bugged and won't show up. I'm stumped, no individual component of the plot seems to be responsible, but the overall plot itself isn't much different from the others that currently work.